### PR TITLE
Fix unclosed string literal problem

### DIFF
--- a/src/lexer/lexer.h
+++ b/src/lexer/lexer.h
@@ -48,6 +48,17 @@ public:
     virtual ~WrongEscapeSequenceError() override = default;
 };
 
+class UnclosedStringLiteralError : public complog::CompilationMessage {
+private:
+    locators::Locator position;
+    std::string badsequence;
+public:
+    UnclosedStringLiteralError(const locators::Locator& position);
+    void WriteMessageToStream(std::ostream& out, const FormatOptions& opts) const override;
+    std::vector<locators::Locator> Locators() const override;
+    virtual ~UnclosedStringLiteralError() override = default;
+};
+
 class Token {
 public: 
     Span span;

--- a/src/lexer/tests/CMakeLists.txt
+++ b/src/lexer/tests/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_executable(lexer_tests main.cpp goodtest1.cpp goodtest2.cpp badtest1.cpp badtest2.cpp)
+add_executable(lexer_tests main.cpp goodtest1.cpp goodtest2.cpp badtest1.cpp badtest2.cpp badtest3.cpp)
 target_link_libraries(lexer_tests PRIVATE test_features lexer)
 add_test(NAME lexer_tests COMMAND lexer_tests)

--- a/src/lexer/tests/badtest3.cpp
+++ b/src/lexer/tests/badtest3.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+#include "locators/locator.h"
+#include "complog/CompilationLog.h"
+#include "lexer.h"
+using namespace std;
+
+static const char* CODE = "var a := \"hello";
+
+TEST(badtests, unclosed_quote) {
+    auto file = make_shared<locators::CodeFile>("BadTest3.d", CODE);
+    complog::AccumulatedCompilationLog log;
+    auto maybeTokens = Lexer::tokenize(file, log);
+    ASSERT_FALSE(maybeTokens.has_value());
+    auto msgs = log.Messages();
+    ASSERT_NE(msgs.size(), 0ul);
+    bool hasErrors = false;
+    bool pointsToEnd = false;
+    for (auto& msg : msgs) {
+        hasErrors = hasErrors || msg->MessageSeverity() == complog::Severity::Error();
+        for (auto& loc : msg->Locators())
+            pointsToEnd = pointsToEnd || loc.Position() == 15;
+    }
+    EXPECT_TRUE(hasErrors);
+    EXPECT_TRUE(pointsToEnd);
+}


### PR DESCRIPTION
the program

```
var a := "hello
```

added as a testcase.